### PR TITLE
Fixed the wss request creation method to the default SSL port.

### DIFF
--- a/src/main/scala/spinoco/fs2/http/websocket/WebSocketRequest.scala
+++ b/src/main/scala/spinoco/fs2/http/websocket/WebSocketRequest.scala
@@ -45,7 +45,7 @@ object WebSocketRequest {
   }
 
   def wss(host: String, path: String, params: (String, String)*): WebSocketRequest =
-    ws(host, 443, path, params:_*)
+    wss(host, 443, path, params:_*)
 
 
 


### PR DESCRIPTION
The default WSS secure websocket method is not setting `secure = true`.